### PR TITLE
Release 1.0.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -23,9 +23,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.3.1
+        uses: azure/setup-helm@v5.0.0
         with:
-          version: v3.15.1
+          version: v4.1.3
 
       - name: Set up dependencies
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,15 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.1
+        uses: azure/setup-helm@v5.0.0
+        with:
+          version: v4.1.3
 
       - name: Set up Python
-        uses: actions/setup-python@v6.0.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.x'
           check-latest: true
@@ -40,7 +42,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@v1.14.0
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/rauthy-helm/CHANGELOG.md
+++ b/charts/rauthy-helm/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.6] - 2026-03-29
+
+### Important, please read
+The appVersion of this helm chart version introduces a breaking change to [Rauthy](https://github.com/sebadob/rauthy).
+Read more: https://github.com/sebadob/rauthy/releases/tag/v0.35.0
+
+### Changed
+- chore(ci): update actions
+- chore(deps): bump appVersion
+
 ## [1.0.5] - 2026-01-26
 
 ### Changed

--- a/charts/rauthy-helm/Chart.yaml
+++ b/charts/rauthy-helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: rauthy-helm
 description: A Helm chart for Rauthy
 type: application
-version: 1.0.5
-appVersion: "0.34.3"
+version: 1.0.6
+appVersion: "0.35.0"
 home: https://github.com/Reversing0148/rauthy-helm
 icon: https://sebadob.github.io/rauthy/rauthy_grey_small.png
 sources:

--- a/charts/rauthy-helm/README.md
+++ b/charts/rauthy-helm/README.md
@@ -17,13 +17,13 @@ This helm chart aims to make your deployment and maintenance of rauthy easier in
 
 ## Installation
 ```bash
-helm upgrade --install rauthy oci://ghcr.io/reversing0148/rauthy-helm --version 1.0.5 -n rauthy --create-namespace
+helm upgrade --install rauthy oci://ghcr.io/reversing0148/rauthy-helm --version 1.0.6 -n rauthy --create-namespace
 ```
 
 ## Upgrading
 Please check the [Generating rauthy configuration](#generating-rauthy-configuration) section before upgrading to avoid data loss!
 ```bash
-helm upgrade --install rauthy oci://ghcr.io/reversing0148/rauthy-helm --version 1.0.5 -n rauthy
+helm upgrade --install rauthy oci://ghcr.io/reversing0148/rauthy-helm --version 1.0.6 -n rauthy
 ```
 
 ## Uninstallation


### PR DESCRIPTION
## [1.0.6] - 2026-03-29

### Important, please read
The appVersion of this helm chart version introduces a breaking change to [Rauthy](https://github.com/sebadob/rauthy).
Read more: https://github.com/sebadob/rauthy/releases/tag/v0.35.0

### Changed
- chore(ci): update actions
- chore(deps): bump appVersion